### PR TITLE
Endstop Trigger FIX

### DIFF
--- a/grbl/limits.c
+++ b/grbl/limits.c
@@ -69,9 +69,11 @@ void limits_init()
 		GPIO_EXTILineConfig(GPIO_LIMIT_PORT, Z_LIMIT_BIT);
 
 		EXTI_InitTypeDef EXTI_InitStructure;
-		EXTI_InitStructure.EXTI_Line = LIMIT_MASK;    //
-		EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt; //Interrupt mode, optional values for the interrupt EXTI_Mode_Interrupt and event EXTI_Mode_Event.
-		EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Falling; //Trigger mode, can be a falling edge trigger EXTI_Trigger_Falling, the rising edge triggered EXTI_Trigger_Rising, or any level (rising edge and falling edge trigger EXTI_Trigger_Rising_Falling)
+		EXTI_InitStructure.EXTI_Line = LIMIT_MASK;
+		//Interrupt mode, optional values for the interrupt EXTI_Mode_Interrupt and event EXTI_Mode_Event.
+		EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
+		//Trigger mode, can be a falling edge trigger EXTI_Trigger_Falling, the rising edge triggered EXTI_Trigger_Rising, or any level (rising edge and falling edge trigger EXTI_Trigger_Rising_Falling)
+		EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
 		EXTI_InitStructure.EXTI_LineCmd = ENABLE;
 		EXTI_Init(&EXTI_InitStructure);
 


### PR DESCRIPTION
Change triggering of the endstop by the front.
It is necessary when the endstop are normally closed, to the rising edge.

Also compatibility with the falling front is maintained.